### PR TITLE
Fix `make test` error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ _output
 gopath
 dockerbuild
 
+vendor
 *.out
 logs

--- a/cmd/yurt-app-manager/app/core.go
+++ b/cmd/yurt-app-manager/app/core.go
@@ -106,14 +106,14 @@ func Run(opts *options.YurtAppOptions) {
 	setRestConfig(cfg)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                  scheme,
-		MetricsBindAddress:      opts.MetricsAddr,
-		HealthProbeBindAddress:  opts.HealthProbeAddr,
-		LeaderElection:          opts.EnableLeaderElection,
-		LeaderElectionID:        "yurt-app-manager",
-		LeaderElectionNamespace: opts.LeaderElectionNamespace,
+		Scheme:                     scheme,
+		MetricsBindAddress:         opts.MetricsAddr,
+		HealthProbeBindAddress:     opts.HealthProbeAddr,
+		LeaderElection:             opts.EnableLeaderElection,
+		LeaderElectionID:           "yurt-app-manager",
+		LeaderElectionNamespace:    opts.LeaderElectionNamespace,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock, // use lease to election
-		Namespace:               opts.Namespace,
+		Namespace:                  opts.Namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -946,6 +947,7 @@ golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
@@ -970,6 +972,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/yurtappmanager/util/refmanager/ref_manager_test.go
+++ b/pkg/yurtappmanager/util/refmanager/ref_manager_test.go
@@ -89,12 +89,12 @@ func Test(t *testing.T) {
 		},
 	}
 
-	getOwner = func(owner metav1.Object, schema *runtime.Scheme, c client.Client) (runtime.Object, error) {
+	getOwner = func(owner metav1.Object, schema *runtime.Scheme, c client.Client) (client.Object, error) {
 		return sts, nil
 	}
 
 	var ownerRefs []metav1.OwnerReference
-	updateOwnee = func(obj runtime.Object, c client.Client) (err error) {
+	updateOwnee = func(obj client.Object, c client.Client) (err error) {
 		ownerRefs = obj.(*corev1.Pod).OwnerReferences
 		return nil
 	}

--- a/pkg/yurtappmanager/webhook/server.go
+++ b/pkg/yurtappmanager/webhook/server.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	webhookutil "github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/util"
 	webhookcontroller "github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/util/controller"


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Run `make test` raise error ` cannot use (func(owner metav1.Object, schema *runtime.Scheme, c client.Client) (runtime.Object, error) literal)
 (value of type func(owner "k8s.io/apimachinery/pkg/apis/meta/v1".Object, schema *runtime.Scheme, c client.Client)
 (runtime.Object, error)) as
 func(owner "k8s.io/apimachinery/pkg/apis/meta/v1".Object, schema *runtime.Scheme, c client.Client) (client.Object, error) value in assignment
`


