### PR TITLE
Initialize capabilities to support enabling containers[*].securityContext.privileged for UnitedDeployment

### DIFF
--- a/pkg/yurtappmanager/webhook/add_uniteddeployment.go
+++ b/pkg/yurtappmanager/webhook/add_uniteddeployment.go
@@ -22,18 +22,9 @@ import (
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/util/gate"
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/uniteddeployment/mutating"
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/uniteddeployment/validating"
-	"k8s.io/kubernetes/pkg/capabilities"
 )
 
 func init() {
-	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: true,
-		PrivilegedSources: capabilities.PrivilegedSources{
-			HostNetworkSources: []string{},
-			HostPIDSources:     []string{},
-			HostIPCSources:     []string{},
-		},
-	})
 	if !gate.ResourceEnabled(&unitv1alpha1.UnitedDeployment{}) {
 		return
 	}

--- a/pkg/yurtappmanager/webhook/add_uniteddeployment.go
+++ b/pkg/yurtappmanager/webhook/add_uniteddeployment.go
@@ -22,9 +22,18 @@ import (
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/util/gate"
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/uniteddeployment/mutating"
 	"github.com/openyurtio/yurt-app-manager/pkg/yurtappmanager/webhook/uniteddeployment/validating"
+	"k8s.io/kubernetes/pkg/capabilities"
 )
 
 func init() {
+	capabilities.Initialize(capabilities.Capabilities{
+		AllowPrivileged: true,
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{},
+			HostPIDSources:     []string{},
+			HostIPCSources:     []string{},
+		},
+	})
 	if !gate.ResourceEnabled(&unitv1alpha1.UnitedDeployment{}) {
 		return
 	}

--- a/pkg/yurtappmanager/webhook/server.go
+++ b/pkg/yurtappmanager/webhook/server.go
@@ -19,10 +19,10 @@ package webhook
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/pkg/capabilities"
 	"time"
 
 	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/capabilities"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/pkg/yurtappmanager/webhook/server.go
+++ b/pkg/yurtappmanager/webhook/server.go
@@ -19,6 +19,7 @@ package webhook
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/pkg/capabilities"
 	"time"
 
 	"k8s.io/klog"
@@ -37,6 +38,17 @@ var (
 
 	Checker = health.Checker
 )
+
+func init() {
+	capabilities.Initialize(capabilities.Capabilities{
+		AllowPrivileged: true,
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{},
+			HostPIDSources:     []string{},
+			HostIPCSources:     []string{},
+		},
+	})
+}
 
 func addHandlers(m map[string]webhookutil.Handler) {
 	for path, handler := range m {


### PR DESCRIPTION
#### What type of PR is this?
 /kind feature

#### What this PR does / why we need it:

Currently, enabling `containers[*].securityContext.privileged`  of `UnitedDeployment` is forbidden even when `--allow-privileged` 
 is enabled in kube apiserver. For example, applying the yaml below will get a "`disallowed by cluster policy`" complain by admission webhook `vuniteddeployment.kb.io`.



```
apiVersion: apps.openyurt.io/v1alpha1
kind: UnitedDeployment
metadata:
  name: test-privileged
spec:
  selector:
    matchLabels:
      app: test-privileged
  workloadTemplate:
    deploymentTemplate:
      metadata:
        labels:
          app: test-privileged
      spec:
        template:
          metadata:
            labels:
              app: test-privileged
          spec:
            containers:
            - name: test-privileged
              image: wawlian/prom-demo:0.1
              imagePullPolicy: Always
              command: ["/usr/bin/prom-demo"]
              securityContext:
                capabilities:
                  add: ["CAP_SYS_ADMIN", "CAP_SYS_RAWIO", "CAP_SYS_MODULE", "CAP_SYS_RESOURCE", "CAP_AUDIT_CONTROL", "CAP_NET_ADMIN"]
                privileged: true
            imagePullSecrets:
              - name: regsecret
  topology:
    pools:
    - name: zone1
      nodeSelectorTerm:
        matchExpressions:
        - key: apps.openyurt.io/nodepool
          operator: In
          values:
          - np001
      replicas: 1
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note
