### PR TITLE
Fix a bug. A node'label will be deleted if it deleted from a nodepool…

### DIFF
--- a/pkg/yurtappmanager/apis/apps/v1alpha1/well_known_labels_annotations.go
+++ b/pkg/yurtappmanager/apis/apps/v1alpha1/well_known_labels_annotations.go
@@ -50,6 +50,8 @@ const (
 	// belonging to
 	LabelCurrentYurtAppDaemon = "apps.openyurt.io/yurtappdaemon"
 
+	AnnotationNodePrevAttrs = "nodepool.openyurt.io/node-attributes"
+
 	AnnotationPrevAttrs = "nodepool.openyurt.io/previous-attributes"
 
 	// DefaultCloudNodePoolName defines the name of the default cloud nodepool


### PR DESCRIPTION
… that has the same label

https://github.com/openyurtio/yurt-app-manager/issues/41


I add an annotation to record the node'label and annotations and taints.
When I need to delete the node from a nodePool. I will change the node' attribute according to this annotation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
