### PR TITLE
【FIX】fix revisionHistoryLimit is not exist

### DIFF
--- a/pkg/yurtappmanager/controller/uniteddeployment/revision.go
+++ b/pkg/yurtappmanager/controller/uniteddeployment/revision.go
@@ -153,7 +153,11 @@ func (r *ReconcileUnitedDeployment) constructUnitedDeploymentRevisions(ud *appsa
 func (r *ReconcileUnitedDeployment) cleanExpiredRevision(ud *appsalphav1.UnitedDeployment,
 	sortedRevisions *[]*apps.ControllerRevision) (*[]*apps.ControllerRevision, error) {
 
-	exceedNum := len(*sortedRevisions) - int(*ud.Spec.RevisionHistoryLimit)
+	var revisionHistoryLimit int
+	if ud.Spec.RevisionHistoryLimit != nil {
+		revisionHistoryLimit = int(*ud.Spec.RevisionHistoryLimit)
+	}
+	exceedNum := len(*sortedRevisions) - revisionHistoryLimit
 	if exceedNum <= 0 {
 		return sortedRevisions, nil
 	}


### PR DESCRIPTION



#### What type of PR is this?
> /kind bug



#### What this PR does / why we need it:
When I deploy yurt-app-manager, and the cluster is also have some uniteddeployment, the yurt-app-manager is not run success, the error is:
![image](https://user-images.githubusercontent.com/70508195/168558744-e113f429-7464-4d3d-991d-ddf024501f83.png)
![image](https://user-images.githubusercontent.com/70508195/168558807-5f93d7ff-1c79-4f0a-bc87-07eb03703985.png)

The reason is `ud.Spec.RevisionHistoryLimit` is not exist, but the code use it's pointer to get the value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
