### PR TITLE
enable ci to verify go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,13 @@ env:
 
 jobs:
 
-  check-license:
+  verify:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run Check License
-        run: hack/make-rules/check_license.sh
+      - name: Verify Code
+        run: make verify
 
   golangci-lint:
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,17 @@ docker-push:
 clean: 
 	-rm -Rf _output
 
+# verify will verify the code.
+verify: verify-mod verify-license
+
+# verify-license will check if license has been added to files. 
+verify-license:
+	hack/make-rules/check_license.sh
+
+# verify-mod will check if go.mod has beed tidied.
+verify-mod:
+	hack/make-rules/verify_mod.sh
+
 generate: controller-gen manifests generate-goclient
 
 # Generate manifests, e.g., CRD, RBAC etc.

--- a/hack/make-rules/verify_mod.sh
+++ b/hack/make-rules/verify_mod.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The OpenYurt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+YURT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+go mod tidy
+
+if [ ! -z "$(git diff ${YURT_ROOT}/go.mod ${YURT_ROOT}/go.sum)" ]; then
+    echo "Verify go mod error, please ensure go.mod has been tidied"
+    exit -1
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind enhancement




#### What this PR does / why we need it:
Currently, we have no way to check if `go.mod` in a pr has been tidied. 
We should do that to make sure all pr has run `go mod tidy` before being merged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
