### PR TITLE
node change nodepool taints should update

### DIFF
--- a/pkg/yurtappmanager/controller/nodepool/nodepool_controller.go
+++ b/pkg/yurtappmanager/controller/nodepool/nodepool_controller.go
@@ -388,19 +388,18 @@ func conciliateAnnotations(node *corev1.Node, oldAnnos, newAnnos map[string]stri
 
 // conciliateLabels will update the node's taint that related to the nodepool
 func conciliateTaints(node *corev1.Node, oldTaints, newTaints []corev1.Taint) {
+
 	// 1. remove taints from the node if they have been removed from the
 	// node pool
 	for _, oldTaint := range oldTaints {
-		if _, exist := containTaint(oldTaint, newTaints); !exist {
+		if _, exist := containTaint(oldTaint, node.Spec.Taints); exist {
 			node.Spec.Taints = removeTaint(oldTaint, node.Spec.Taints)
 		}
 	}
 
 	// 2. update the node taints based on the latest node pool taints
 	for _, nt := range newTaints {
-		if _, exist := containTaint(nt, oldTaints); !exist {
-			node.Spec.Taints = append(node.Spec.Taints, nt)
-		}
+		node.Spec.Taints = append(node.Spec.Taints, nt)
 	}
 }
 

--- a/pkg/yurtappmanager/controller/nodepool/nodepool_controller_test.go
+++ b/pkg/yurtappmanager/controller/nodepool/nodepool_controller_test.go
@@ -703,6 +703,14 @@ var testTaints []corev1.Taint = []corev1.Taint{
 	},
 }
 
+var currentTaints = []corev1.Taint{
+	{
+		Key:    "foo",
+		Value:  "beijing",
+		Effect: corev1.TaintEffectNoExecute,
+	},
+}
+
 var testNPRA1 NodePoolRelatedAttributes = NodePoolRelatedAttributes{
 	Labels:      testLabel1,
 	Annotations: testAnnotations,
@@ -818,6 +826,42 @@ func TestConciliateNode(t *testing.T) {
 				},
 			},
 			false,
+		},
+		{
+			"node change nodepool",
+			// use DeepCopy because of the side effects
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo":                             "bar",
+						"buz":                             "qux",
+						appsv1alpha1.LabelCurrentNodePool: "test",
+					},
+					Annotations: map[string]string{
+						"foo":                            "qux",
+						"buz":                            "qux",
+						appsv1alpha1.AnnotationPrevAttrs: string(npraBytes),
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: testTaints,
+				},
+			},
+			appsv1alpha1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: appsv1alpha1.NodePoolSpec{
+					Labels: map[string]string{
+						"foo":                             "bar",
+						"buz":                             "qux",
+						appsv1alpha1.LabelCurrentNodePool: "test",
+					},
+					Annotations: testAnnotations,
+					Taints:      currentTaints,
+				},
+			},
+			true,
 		},
 		{
 			"outdated npra attrs",


### PR DESCRIPTION
Signed-off-by: huiwq1990 <huiwq1990@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage



#### What this PR does / why we need it:

If one node join nodepool which have taints, after we change the nodepool of the node, node taints will not change.
![image](https://user-images.githubusercontent.com/4555057/189265358-5e40b8b8-084e-4a03-a831-3d7535fcc5fb.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
