### PR TITLE
feat: add NodePool.Spec.Type to NodePool labels

### DIFF
--- a/pkg/yurtappmanager/apis/apps/v1alpha1/nodepool_types.go
+++ b/pkg/yurtappmanager/apis/apps/v1alpha1/nodepool_types.go
@@ -26,6 +26,8 @@ type NodePoolType string
 const (
 	Edge  NodePoolType = "Edge"
 	Cloud NodePoolType = "Cloud"
+
+	NodePoolTypeLabelKey = "openyurt.io/node-pool-type"
 )
 
 // NodePoolSpec defines the desired state of NodePool

--- a/pkg/yurtappmanager/apis/apps/v1beta1/nodepool_types.go
+++ b/pkg/yurtappmanager/apis/apps/v1beta1/nodepool_types.go
@@ -26,6 +26,8 @@ type NodePoolType string
 const (
 	Edge  NodePoolType = "Edge"
 	Cloud NodePoolType = "Cloud"
+
+	NodePoolTypeLabelKey = "openyurt.io/node-pool-type"
 )
 
 // NodePoolSpec defines the desired state of NodePool

--- a/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
+++ b/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
@@ -17,6 +17,7 @@ package nodepool
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +64,7 @@ func (webhook *NodePoolHandler) Default(ctx context.Context, obj runtime.Object)
 	if np.Labels == nil {
 		np.Labels = make(map[string]string)
 	}
-	np.Labels[v1alpha1.NodePoolTypeLabelKey] = string(np.Spec.Type)
+	np.Labels[v1alpha1.NodePoolTypeLabelKey] = strings.ToLower(string(np.Spec.Type))
 
 	return nil
 }

--- a/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
+++ b/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
@@ -60,6 +60,9 @@ func (webhook *NodePoolHandler) Default(ctx context.Context, obj runtime.Object)
 	}
 
 	// add NodePool.Spec.Type to NodePool labels
+	if np.Labels == nil {
+		np.Labels = make(map[string]string)
+	}
 	np.Labels[v1alpha1.NodePoolTypeLabelKey] = string(np.Spec.Type)
 
 	return nil

--- a/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
+++ b/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook.go
@@ -59,6 +59,9 @@ func (webhook *NodePoolHandler) Default(ctx context.Context, obj runtime.Object)
 		MatchLabels: map[string]string{v1alpha1.LabelCurrentNodePool: np.Name},
 	}
 
+	// add NodePool.Spec.Type to NodePool labels
+	np.Labels[v1alpha1.NodePoolTypeLabelKey] = string(np.Spec.Type)
+
 	return nil
 }
 

--- a/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook_test.go
+++ b/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook_test.go
@@ -42,6 +42,10 @@ func TestNodePoolDefaulter(t *testing.T) {
 	if err := webhook.Default(context.TODO(), defaultNodePool); err != nil {
 		t.Fatal(err)
 	}
+	if defaultNodePool.Labels[v1alpha1.NodePoolTypeLabelKey] != string(defaultNodePool.Spec.Type) {
+		t.Fatalf("the default NodePool label doesn't match NodePool.Spec.Type. label:%s, type:%s",
+			defaultNodePool.Labels[v1alpha1.NodePoolTypeLabelKey], string(defaultNodePool.Spec.Type))
+	}
 }
 
 func TestNodePoolValidator(t *testing.T) {

--- a/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook_test.go
+++ b/pkg/yurtappmanager/webhook/nodepool/nodepool_webhook_test.go
@@ -16,6 +16,7 @@ package nodepool
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,7 @@ func TestNodePoolDefaulter(t *testing.T) {
 	if err := webhook.Default(context.TODO(), defaultNodePool); err != nil {
 		t.Fatal(err)
 	}
-	if defaultNodePool.Labels[v1alpha1.NodePoolTypeLabelKey] != string(defaultNodePool.Spec.Type) {
+	if defaultNodePool.Labels[v1alpha1.NodePoolTypeLabelKey] != strings.ToLower(string(defaultNodePool.Spec.Type)) {
 		t.Fatalf("the default NodePool label doesn't match NodePool.Spec.Type. label:%s, type:%s",
 			defaultNodePool.Labels[v1alpha1.NodePoolTypeLabelKey], string(defaultNodePool.Spec.Type))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
The type of NodePool is not a label. So it cannot be selected easily.
When NodePool being created, we can mutate it to add a label which is same as the NodePool.Spec.Type.
Then different type of NodePool could be selected by k8s label selector.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #125 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
@rambohe-ch @kadisi 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
The NodePool.Spec.Type will be added to NodePool.Labels and user can select different NodePool easily.
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
