### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/pkg/yurtappmanager/apis/apps/v1alpha1/defaults.go
+++ b/pkg/yurtappmanager/apis/apps/v1alpha1/defaults.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultIngressControllerImage     string = "k8s.gcr.io/ingress-nginx/controller:v0.48.1"
+	defaultIngressControllerImage     string = "registry.k8s.io/ingress-nginx/controller:v0.48.1"
 	defaultIngressWebhookCertGenImage string = "docker.io/jettech/kube-webhook-certgen:v1.5.1"
 )
 

--- a/pkg/yurtappmanager/webhook/yurtingress/yurtingress_webhook_test.go
+++ b/pkg/yurtappmanager/webhook/yurtingress/yurtingress_webhook_test.go
@@ -34,8 +34,8 @@ var defaultYurtIngress = &v1alpha1.YurtIngress{
 	},
 	Spec: v1alpha1.YurtIngressSpec{
 		Replicas:                   1,
-		IngressControllerImage:     "k8s.gcr.io/ingress-nginx/controller:v0.49.0",
-		IngressWebhookCertGenImage: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v0.49.0",
+		IngressControllerImage:     "registry.k8s.io/ingress-nginx/controller:v0.49.0",
+		IngressWebhookCertGenImage: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v0.49.0",
 		Pools:                      []v1alpha1.IngressPool{{Name: "beijing"}},
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind documentation

#### What this PR does / why we need it:
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Migrate from k8s.gcr.io to registry.k8s.io
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
